### PR TITLE
Change Codeship to GitHub Actions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: Run Tests
 
 on:
   push:
-    branches: [ krc/add-github-actions ]
+    branches: [ master ]
   pull_request:
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,7 +2,7 @@ name: Run Tests
 
 on:
   push:
-    branches: [ krc/add-github-actions ]
+    branches: [ main ]
   pull_request:
 
 jobs:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,7 @@ jobs:
           coverage: none
 
     - name: Install dependencies
-      run: composer install --prefer-source --no-interaction
+      run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
         
     - name: Run PHP tests
       run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -39,6 +39,12 @@ jobs:
 
     - name: Install dependencies
       run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
+
+    - name: Copy .env.example as .env
+      run: cp .env.example .env
         
+    - name: Generate App Key
+      run: php artisan key:generate
+
     - name: Run PHP tests
       run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, Windows, macOS]
-        php: [7.2, 7.3, 7.4, 8.0]
+        php: [7.2, 7.3, 7.4]
 
         include:
         - os: Ubuntu

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,44 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        os: [Ubuntu, Windows, macOS]
+        php: [7.2, 7.3, 7.4, 8.0]
+
+        include:
+        - os: Ubuntu
+        os-version: ubuntu-latest
+
+        - os: Windows
+        os-version: windows-latest
+
+        - os: macOS
+        os-version: macos-latest
+
+    name: ${{ matrix.os }} - PHP ${{ matrix.php }}
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v1
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+          php-version: ${{ matrix.php }}
+          extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
+
+    - name: Install dependencies
+      run: composer install --prefer-source --no-interaction
+        
+    - name: Run PHP tests
+      run: vendor/bin/phpunit

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,24 +7,24 @@ on:
 
 jobs:
   tests:
-    runs-on: ubuntu-latest
-
     strategy:
-      matrix:
-        os: [Ubuntu, Windows, macOS]
-        php: [7.2, 7.3, 7.4, 8.0]
+        matrix:
+            os: [Ubuntu, Windows, macOS]
+            php: [7.2, 7.3, 7.4, 8.0]
 
-        include:
-        - os: Ubuntu
-        os-version: ubuntu-latest
+            include:
+              - os: Ubuntu
+                os-version: ubuntu-latest
 
-        - os: Windows
-        os-version: windows-latest
+              - os: Windows
+                os-version: windows-latest
 
-        - os: macOS
-        os-version: macos-latest
+              - os: macOS
+                os-version: macos-latest
 
     name: ${{ matrix.os }} - PHP ${{ matrix.php }}
+
+    runs-on: ${{ matrix.os-version }}
 
     steps:
     - name: Checkout code

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-          php-version: 7.4
+          php-version: 7.3
           extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, Windows, macOS]
-        php: [7.2, 7.3, 7.4]
+        php: [7.2, 7.3]
 
         include:
         - os: Ubuntu

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,25 +2,25 @@ name: Run Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ krc/add-github-actions ]
   pull_request:
 
 jobs:
   tests:
     strategy:
-        matrix:
-            os: [Ubuntu, Windows, macOS]
-            php: [7.2, 7.3, 7.4, 8.0]
+      matrix:
+        os: [Ubuntu, Windows, macOS]
+        php: [7.2, 7.3, 7.4, 8.0]
 
-            include:
-              - os: Ubuntu
-                os-version: ubuntu-latest
+        include:
+        - os: Ubuntu
+          os-version: ubuntu-latest
 
-              - os: Windows
-                os-version: windows-latest
+        - os: Windows
+          os-version: windows-latest
 
-              - os: macOS
-                os-version: macos-latest
+        - os: macOS
+          os-version: macos-latest
 
     name: ${{ matrix.os }} - PHP ${{ matrix.php }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,7 +22,7 @@ jobs:
           coverage: none
 
     - name: Install dependencies
-      run: composer install --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
+      run: composer install --prefer-source --no-interaction
 
     - name: Copy .env.example as .env
       run: cp .env.example .env

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,29 +2,13 @@ name: Run Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ krc/add-github-actions ]
   pull_request:
 
 jobs:
   tests:
-    strategy:
-      matrix:
-        os: [Ubuntu, Windows, macOS]
-        php: [7.2, 7.3]
-
-        include:
-        - os: Ubuntu
-          os-version: ubuntu-latest
-
-        - os: Windows
-          os-version: windows-latest
-
-        - os: macOS
-          os-version: macos-latest
-
-    name: ${{ matrix.os }} - PHP ${{ matrix.php }}
-
-    runs-on: ${{ matrix.os-version }}
+    name: Tests
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
@@ -33,12 +17,12 @@ jobs:
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
       with:
-          php-version: ${{ matrix.php }}
+          php-version: 7.4
           extensions: posix, dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
           coverage: none
 
     - name: Install dependencies
-      run: composer update --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
+      run: composer install --prefer-stable --prefer-dist --no-interaction --no-suggest --ignore-platform-reqs
 
     - name: Copy .env.example as .env
       run: cp .env.example .env

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ![ConFOMO logo](https://raw.githubusercontent.com/tightenco/confomo/master/confomo-logo.png)
 
-[![Codeship Status for mattstauffer/confomo](https://codeship.com/projects/5f3d86b0-1335-0134-c5b2-1e1a7920036c/status?branch=master)](https://codeship.com/projects/157478)
+[![Run tests](https://github.com/tighten/takeout/workflows/Run%20tests/badge.svg?branch=main)](https://github.com/tighten/confomo/actions?query=workflow%3A%22Run+Tests%22)
 
 ### Connecting your online community with the real world, one conference at a time.
 
@@ -10,7 +10,7 @@ Updated for Laravel 5.1 and Vue in 2015/2016. @michaeldyrynda did most of the ha
 
 ### Requirements
 
-- PHP >= 7.1.3
+- PHP = 7.2 or 7.3
 - Composer
 - Node and npm
 


### PR DESCRIPTION
This pull request includes code to run php unit tests on GitHub actions. The codeship badge has been replaced with the GitHub actions badge on the README file and the php requirements have been updated to reflect the testing on GitHub Actions. **TODO: This project should be removed from the codeship site.**

- Added Run Tests GitHub workflow.
- Updated Readme with GitHub Actions badge replacing the codeship badge.
- Updated PHP requirements listed in the README to reflect the versions of php that are passing the GitHub Workflow.
![Screen Shot 2020-12-17 at 1 49 24 PM](https://user-images.githubusercontent.com/7070136/102531685-b3ae6e00-4070-11eb-92da-828bcaaeb911.png)
![Screen Shot 2020-12-17 at 1 49 10 PM](https://user-images.githubusercontent.com/7070136/102531687-b5783180-4070-11eb-9af8-b67d60609b90.png)

